### PR TITLE
fix: update type import paths

### DIFF
--- a/BarChartComponent.tsx
+++ b/BarChartComponent.tsx
@@ -1,7 +1,7 @@
 
 import React from 'react';
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
-import type { ChartDataItem } from '../types';
+import type { ChartDataItem } from './types';
 
 interface BarChartProps {
   title: string;

--- a/Dashboard.tsx
+++ b/Dashboard.tsx
@@ -1,7 +1,7 @@
 
 
 import React from 'react';
-import type { DashboardData, Chart as ChartType } from '../types';
+import type { DashboardData, Chart as ChartType } from './types';
 import KpiCard from './KpiCard';
 import BarChartComponent from './BarChartComponent';
 import PieChartComponent from './PieChartComponent';

--- a/DataTable.tsx
+++ b/DataTable.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useMemo } from 'react';
-import type { CsvRow } from '../types';
+import type { CsvRow } from './types';
 
 interface DataTableProps {
   data: CsvRow[];

--- a/DealCard.tsx
+++ b/DealCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import type { Deal } from '../types';
+import type { Deal } from './types';
 
 interface DealCardProps extends Deal {
   onClick: () => void;

--- a/DealCardCompact.tsx
+++ b/DealCardCompact.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import type { Deal } from '../types';
+import type { Deal } from './types';
 
 interface DealCardCompactProps extends Deal {
   onClick: () => void;

--- a/DealDetailView.tsx
+++ b/DealDetailView.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import type { Deal, CsvRow } from '../types';
+import type { Deal, CsvRow } from './types';
 
 interface DealDetailViewProps {
   deal: Deal;

--- a/DealRow.tsx
+++ b/DealRow.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import type { Deal } from '../types';
+import type { Deal } from './types';
 
 interface DealRowProps extends Deal {
     onClick: () => void;

--- a/DealsView.tsx
+++ b/DealsView.tsx
@@ -1,6 +1,6 @@
 
 import React, { useState, useMemo, useEffect } from 'react';
-import type { Deal, CsvRow } from '../types';
+import type { Deal, CsvRow } from './types';
 import DealCard from './DealCard';
 import DealCardCompact from './DealCardCompact';
 import DealRow from './DealRow';

--- a/FileUpload.tsx
+++ b/FileUpload.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useState } from 'react';
 import Papa, { type ParseResult, type ParseError } from 'papaparse';
-import type { CsvRow } from '../types';
+import type { CsvRow } from './types';
 
 interface FileUploadProps {
   onFileProcessed: (csvString: string, data: CsvRow[], fileName: string) => void;

--- a/KpiCard.tsx
+++ b/KpiCard.tsx
@@ -1,6 +1,6 @@
 
 import React from 'react';
-import type { Kpi } from '../types';
+import type { Kpi } from './types';
 
 const KpiCard: React.FC<Kpi> = ({ title, value, insight }) => {
   return (

--- a/MeetingAnalysisCard.tsx
+++ b/MeetingAnalysisCard.tsx
@@ -1,6 +1,6 @@
 
 import React, { useState } from 'react';
-import type { MeetingAnalysis } from '../types';
+import type { MeetingAnalysis } from './types';
 
 interface MeetingAnalysisCardProps {
     meeting: MeetingAnalysis;

--- a/PieChartComponent.tsx
+++ b/PieChartComponent.tsx
@@ -1,7 +1,7 @@
 
 import React from 'react';
 import { PieChart, Pie, Cell, Tooltip, Legend, ResponsiveContainer } from 'recharts';
-import type { ChartDataItem } from '../types';
+import type { ChartDataItem } from './types';
 
 interface PieChartProps {
   title: string;

--- a/SuggestionCard.tsx
+++ b/SuggestionCard.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import type { UpdateSuggestion, CreationSuggestion } from '../types';
+import type { UpdateSuggestion, CreationSuggestion } from './types';
 
 interface SuggestionCardProps {
     suggestion: UpdateSuggestion | CreationSuggestion;

--- a/SuggestionsView.tsx
+++ b/SuggestionsView.tsx
@@ -1,6 +1,6 @@
 
 import React from 'react';
-import type { UpdateSuggestion, CreationSuggestion } from '../types';
+import type { UpdateSuggestion, CreationSuggestion } from './types';
 import SuggestionCard from './SuggestionCard';
 
 interface SuggestionsViewProps {

--- a/TranscriptAnalysisDisplay.tsx
+++ b/TranscriptAnalysisDisplay.tsx
@@ -1,6 +1,6 @@
 
 import React from 'react';
-import type { TranscriptAnalysisResult, UpdateSuggestion, CreationSuggestion } from '../types';
+import type { TranscriptAnalysisResult, UpdateSuggestion, CreationSuggestion } from './types';
 import SuggestionsView from './SuggestionsView';
 import MeetingAnalysisCard from './MeetingAnalysisCard';
 

--- a/TranscriptAnalyzer.tsx
+++ b/TranscriptAnalyzer.tsx
@@ -1,6 +1,6 @@
 
 import React, { useState, useCallback } from 'react';
-import type { TranscriptAnalysisResult, UpdateSuggestion, CreationSuggestion } from '../types';
+import type { TranscriptAnalysisResult, UpdateSuggestion, CreationSuggestion } from './types';
 import TranscriptAnalysisDisplay from './TranscriptAnalysisDisplay';
 import * as pdfjs from 'pdfjs-dist/build/pdf.mjs';
 import mammoth from 'mammoth';

--- a/geminiService.ts
+++ b/geminiService.ts
@@ -1,6 +1,6 @@
 
 import { GoogleGenAI, Type } from "@google/genai";
-import type { DashboardData, Deal, TranscriptAnalysisResult } from '../types';
+import type { DashboardData, Deal, TranscriptAnalysisResult } from './types';
 
 // Support both GEMINI_API_KEY (documented in README) and legacy API_KEY
 const apiKey = process.env.GEMINI_API_KEY || process.env.API_KEY;


### PR DESCRIPTION
## Summary
- update relative path imports to `./types`

## Testing
- `npm run build` *(fails: `npm` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a8ad098708326a21d535dd50956be